### PR TITLE
Fixes shared_ptr build error on Centos7 with g++ 4.8.3

### DIFF
--- a/src/topic.h
+++ b/src/topic.h
@@ -2,6 +2,7 @@
 #define TOPIC_H_
 
 #include <unordered_set>
+#include <memory>
 #include "client.h"
 
 namespace mc0 {

--- a/vendor/cppzmq/zmq.hpp
+++ b/vendor/cppzmq/zmq.hpp
@@ -62,6 +62,11 @@
 
 #if ZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 1, 0)
 #define ZMQ_HAS_PROXY_STEERABLE
+/*  Socket event data  */
+typedef struct {
+    uint16_t event;  // id of the event as bitfield
+    int32_t  value ; // value is either error code, fd or reconnect interval
+} zmq_event_t;
 #endif
 
 // In order to prevent unused variable warnings when building in non-debug


### PR DESCRIPTION
This fixes building mc0d on CentOs7 with g++ 4.8.3

Without this, make would always end with following errror:

```
[ 52%] Building CXX object src/CMakeFiles/mc0d.dir/mc0d_main.cpp.o
In file included from /root/mc0d/src/broker.h:5:0,
                 from /root/mc0d/src/mc0d_main.cpp:1:
/root/mc0d/src/topic.h:12:24: error: 'shared_ptr' is not a member of 'std'
     std::unordered_set<std::shared_ptr<Client>> subscribers;
                        ^
```
